### PR TITLE
tweak(library): Support down to go 1.12.

### DIFF
--- a/api_backend.go
+++ b/api_backend.go
@@ -68,16 +68,13 @@ func (c *APIBackend) request(method string, url string,
 
 	fullURL := fmt.Sprintf("%s%s", c.BaseURL, url)
 
-	if requestParams.Context == nil {
-		req, err = http.NewRequest(method, fullURL, body)
-		if err != nil {
-			return res, err
-		}
-	} else {
-		req, err = http.NewRequestWithContext(requestParams.Context, method, fullURL, body)
-		if err != nil {
-			return res, err
-		}
+	req, err = http.NewRequest(method, fullURL, body)
+	if err != nil {
+		return res, err
+	}
+
+	if requestParams.Context != nil {
+		req = req.WithContext(requestParams.Context)
 	}
 
 	req.Header.Add("Accept", "application/json")

--- a/autoscaling_group.go
+++ b/autoscaling_group.go
@@ -44,7 +44,7 @@ type AutoscalingGroupListParams struct {
 
 type AutoscalingGroupUpdateAttributeParams struct {
 	Name        string `json:"name,omitempty"`
-	Min         string `json:"name,omitempty"`
+	Min         string `json:"min,omitempty"`
 	Max         int    `json:"max,omitempty"`
 	Current     int    `json:"current,omitempty"`
 	MachineType string `json:"machineType,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/paperspace/paperspace-go
 
-go 1.14
+go 1.12
+
+require (
+	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
+golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Also cleans up other `go vet` errors.