### PR TITLE
chore(cluster): adding aws region

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -20,6 +20,7 @@ const (
 var ClusterAWSRegions = []string{
 	"us-east-1",
 	"us-east-2",
+	"us-west-1",
 	"us-west-2",
 	"ca-central-1",
 	"eu-west-1",


### PR DESCRIPTION
Can get rid of this: 

https://github.com/Paperspace/gradient-installer/blob/a1fe1fd4880e4b952712a8544f2522b260bafa9e/pkg/cli/commands/clusters/register.go#L67-L70